### PR TITLE
var id VS. $(a).attr("id")

### DIFF
--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -49,7 +49,7 @@
                 id = id ? id : "";
                 var si = id.indexOf("-") + 1;
                 cd = cd.getFullYear() + "-" + cd.getDayForWeek().getWeekOfYear();
-                var ed = $(a).attr("id").substring(si, $(a).attr("id").length);
+                var ed = id.substring(si, id.length);
                 return cd === ed;
             }
         });
@@ -61,7 +61,7 @@
                 var id = $(a).attr("id");
                 id = id ? id : "";
                 var si = id.indexOf("-") + 1;
-                var ed = $(a).attr("id").substring(si, $(a).attr("id").length);
+                var ed = id.substring(si, id.length);
                 return cd === ed;
             }
         });


### PR DESCRIPTION
When running the demo on my local machine, i couldn't 'zoom' out to the month / year view because $(a).attr("id") was returning undefined.  Two lines higher it looks like there is a catch for this, but the catch is not used.

The two modifications made allowed me to view the demo.
