### PR TITLE
Fixed unresolvable variable

### DIFF
--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -1385,7 +1385,7 @@
                 return ret;
             },
             getPageHeight: function (element) {
-                return element.pageNum + 1 === element.pageCount ? rowsOnLastPage * tools.getCellSize() : settings.itemsPerPage * tools.getCellSize();
+                return element.pageNum + 1 === element.pageCount ? element.rowsOnLastPage * tools.getCellSize() : settings.itemsPerPage * tools.getCellSize();
             },
             _getProgressBarMargin: null,
             getProgressBarMargin: function () {


### PR DESCRIPTION
_This bug fix is completely based on what JS parser reported me. I haven't tested if it correctly fixes the error, but I assume so._

`tools.getPageHeight()` refers to a variable called `rowsOnLastPage` which doesn't exist.
