### PR TITLE
Update js/jquery.fn.gantt.js

### DIFF
--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -672,13 +672,14 @@
                     default:
                         range = tools.parseDateRange(element.dateStart, element.dateEnd);
 
-                        var year = range[0].getFullYear();
-                        var month = range[0].getMonth();
-                        var day = range[0];
+						var dateBefore = ktkGetNextDate(range[0], -1);
+                        var year = dateBefore.getFullYear();
+                        var month = dateBefore.getMonth();
+                        var day = dateBefore;
 
                         for (var i = 0; i < range.length; i++) {
                             var rday = range[i];
-
+							
                             // Fill years
                             if (rday.getFullYear() !== year) {
                                 yearArr.push(
@@ -691,7 +692,6 @@
                                 daysInYear = 0;
                             }
                             daysInYear++;
-
 
                             // Fill months
                             if (rday.getMonth() !== month) {
@@ -720,7 +720,6 @@
                                     + ' <div class="fn-label">' + settings.dow[getDay] + '</div></div>');
                         } //for
 
-
                         // Last year
                         yearArr.push(
                             '<div class="row header year" style="width: '
@@ -734,7 +733,7 @@
                             + tools.getCellSize() * daysInMonth + 'px"><div class="fn-label">'
                             + settings.months[month]
                             + '</div></div>');
-
+						
                         var dataPanel = core.dataPanel(element, range.length * tools.getCellSize());
 
 
@@ -1526,19 +1525,30 @@
                 var ret = [];
                 var i = 0;
                 for(;;) {
-                    ret[i] = new Date(current.getTime());
-                    current.setHours(current.getHours() + scaleStep);
-    		
-					// Check before applying floor, to avoid deadlocks.
-					if(current.getTime() > to.getTime()) break;
+					var dayStartTime = new Date(current);
+					dayStartTime.setHours(Math.floor((current.getHours()) / scaleStep) * scaleStep);
 					
-                    current.setHours(Math.floor((current.getHours()) / scaleStep) * scaleStep);
-
-                    if (current.getDay() !== ret[i].getDay()) {
-                        current.setHours(0);
+                    if (ret[i] && dayStartTime.getDay() !== ret[i].getDay()) {
+						// If mark-cursor jumped to next day, make sure it starts at 0 hours
+						dayStartTime.setHours(0);
                     }
+					ret[i] = dayStartTime;
+
+					// Note that we use ">" because we want to include the end-time point.
+					if(current.getTime() > to.getTime()) break;
+
+					/* BUG-2: current is moved backwards producing a dead-lock! (crashes chrome/IE/firefox)
+					 * SEE: https://github.com/taitems/jQuery.Gantt/issues/62
+                    if (current.getDay() !== ret[i].getDay()) {
+                       current.setHours(0);
+                    }
+					*/
+
+					current = ktkGetNextDate(current, scaleStep);
+
                     i++;
                 };
+				
                 return ret;
             },
 
@@ -1686,6 +1696,7 @@
             }
 
             switch (settings.scale) {
+                //case "hours": this.headerRows = 5; this.scaleStep = 8; break;
                 case "hours": this.headerRows = 5; this.scaleStep = 1; break;
                 case "weeks": this.headerRows = 3; this.scaleStep = 13; break;
                 case "months": this.headerRows = 2; this.scaleStep = 14; break;
@@ -1711,3 +1722,17 @@
 
     };
 })(jQuery);
+
+function ktkGetNextDate(currentDate, scaleStep) {
+	for(var minIncrements = 1;; minIncrements++) {
+		var nextDate = new Date(currentDate);
+		nextDate.setHours(currentDate.getHours() + scaleStep * minIncrements);
+
+		if(nextDate.getTime() != currentDate.getTime()) {
+			return nextDate;
+		}
+
+		// If code reaches here, it's because current didn't really increment (invalid local time) because of daylight-saving adjustments
+		// => retry adding 2, 3, 4 hours, and so on (until nextDate > current)
+	}	
+}


### PR DESCRIPTION
Fixes deadlock (and chrome/IE/firefox) crash, because of applying floor to current date (variable doesn't increment).
