### PR TITLE
Modified cursor icon on over gantt bar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -43,6 +43,7 @@
 }
 
 .fn-gantt .row {
+    cursor:pointer;
     float: left;
     height: 24px;
     line-height: 24px;


### PR DESCRIPTION
I think is the default expected behaviour on over, don't you?
