### PR TITLE
Add customClass to bar hover hint

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -183,7 +183,6 @@
     height: 18px;
     margin: 4px 3px 3px 3px;
     position: absolute;
-    z-index: 10;
     text-align: center;
         -webkit-box-shadow: 0 0 1px rgba(0,0,0,0.25) inset;
         -moz-box-shadow: 0 0 1px rgba(0,0,0,0.25) inset;

--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -945,20 +945,22 @@
                         .data("dataObj", dataObj);
 
                 if (desc) {
+                    var hint;
                     bar
                       .mouseover(function (e) {
-                          var hint = $('<div class="fn-gantt-hint" />').html(desc);
-                          $("body").append(hint);
-                          hint.css("left", e.pageX);
-                          hint.css("top", e.pageY);
+                          if (!hint) {
+                              hint = $('<div class="fn-gantt-hint" />').html(desc);
+                          }
+
+                          $(this).append(hint);
+                          core.updateHintPosition(hint, e);
                           hint.show();
                       })
                       .mouseout(function () {
-                          $(".fn-gantt-hint").remove();
+                          hint = hint.detach();
                       })
                       .mousemove(function (e) {
-                          $(".fn-gantt-hint").css("left", e.pageX);
-                          $(".fn-gantt-hint").css("top", e.pageY + 15);
+                          core.updateHintPosition(hint, e);
                       });
                 }
                 bar.click(function (e) {
@@ -966,6 +968,23 @@
                     settings.onItemClick($(this).data("dataObj"));
                 });
                 return bar;
+            },
+
+            // updates the x/y position of the bar hint
+            // offsetX/Y is available in Chrome/IE but not Firefox
+            // see http://bugs.jquery.com/ticket/8523
+            updateHintPosition: function(hint, e) {
+                var hintOffset = 15;
+                var x = e.offsetX, y = e.offsetY;
+
+                if (typeof x === "undefined" || typeof y === "undefined") {
+                    var targetOffset = $(e.target).offset();
+                    x = e.pageX - targetOffset.left;
+                    y = e.pageY - targetOffset.top;
+                }
+
+                hint.css("left", x + hintOffset);
+                hint.css("top", y + hintOffset);
             },
 
             // Remove the `wd` (weekday) class and add `today` class to the


### PR DESCRIPTION
Updated the bar mouseover hint to also include the customClass. This
will give developers more control over the color of the hover. Currently
is defaults to a yellow. Now developers can customize the color of the
hover based on the gantt Color passed in to the values.
