### PR TITLE
pager i18n: pager 'of' text replaced by '/'

### DIFF
--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -769,7 +769,7 @@
                                     }))
                                 .append($('<div class="page-number"/>')
                                         .append($('<span/>')
-                                            .html(element.pageNum + 1 + ' of ' + element.pageCount)))
+                                            .html(element.pageNum + 1 + ' / ' + element.pageCount)))
                                 .append($('<span role="button" class="nav-link nav-page-next"/>')
                                     .html('&gt;')
                                     .click(function () {


### PR DESCRIPTION
https://github.com/taitems/jQuery.Gantt/pull/96 rework

Almost everything was translated dow and month options (non-english enviroment).
This patch helps to translate the rest: pager 'X of Y' text.
