### PR TITLE
Add option to remove pagination and display all rows.

### DIFF
--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -329,7 +329,7 @@
                 var entries = [];
                 $.each(element.data, function (i, entry) {
                     if (!settings.paginate || (i >= element.pageNum * settings.itemsPerPage && i < (element.pageNum * settings.itemsPerPage + settings.itemsPerPage))) {
-                        entries.push('<div class="row name row' + i + (entry.desc ? '' : ' fn-wide') + '" id="rowheader' + i + '" offset="' + i % settings.itemsPerPage * tools.getCellSize() + '">');
+                        entries.push('<div class="row name row' + i + (entry.desc ? '' : ' fn-wide') + '" id="rowheader' + i + '" offset="' + (settings.paginate ? i % settings.itemsPerPage : i) * tools.getCellSize() + '">');
                         entries.push('<span class="fn-label' + (entry.cssClass ? ' ' + entry.cssClass : '') + '">' + entry.name + '</span>');
                         entries.push('</div>');
 


### PR DESCRIPTION
Added a settings option to paginate the view (on by default). Setting this to off will draw all rows of the gantt chart, and will remove the paginate navigation options.

You could re-create similar behaviour by setting the itemsPerPage to a high number (however the navigation would remain) however this is a precursor to the ability to pan up and down the list as well as left and right.

@usmonster you seem to be the most active regarding pull requests?
