### PR TITLE
Fixed bug with getWeekId 

### DIFF
--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -106,13 +106,8 @@
         // the week # for the year.
         // It is used to add an id to the week divs
         Date.prototype.getWeekId = function () {
-            var y = this.getFullYear();
-            var w = this.getDayForWeek().getWeekOfYear();
-            var m = this.getMonth();
-            if (m === 11 && w === 1) {
-                y++;
-            }
-            return 'dh-' + y + "-" + w;
+			var wk = this.getDayForWeek();
+            return 'dh-' + wk.getFullYear() + "-" + wk.getWeekOfYear();
         };
 
         // `getRepDate` returns the seconds since the epoch for a given date


### PR DESCRIPTION
Theres an apparent bug in getWeekId (Dec 31, 2013 would give 'dh-2013-0' instead of...'dh-2014-0'). This appears to be because getDayForWeek might move to the next year (week 0 may include some dates from the previous year). The if (m === 11 && w === 1) { appeared to be a workaround, but doesnt work because week numbers start at 0. However just basing the id of getDayForWeek() seems to fix it and be simpler.