### PR TITLE
added captureVerticalWheel option

### DIFF
--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -44,7 +44,8 @@
             onItemClick: function (data) { return; },
             onAddClick: function (data) { return; },
             onRender: function() { return; },
-            scrollToToday: true
+            scrollToToday: true,
+            captureVerticalWheel: true
         };
 
         /**
@@ -1292,6 +1293,12 @@
 
             // Move chart via mousewheel
             wheelScroll: function (element, e) {
+                
+                if (!settings.captureVerticalWheel && Math.abs(e.originalEvent.deltaY) > Math.abs(e.originalEvent.deltaX)) {
+                    // short-circuit vertical scroll - we do not want to intercept that one!
+                    return
+                }                
+                
                 e.preventDefault(); // e is a jQuery Event
 
                 // attempts to normalize scroll wheel velocity


### PR DESCRIPTION
I did not like that scrolling was done both using the horizontal and vertical axis. I had a few independent charts on a page and I wanted to be able to scroll vertically without having to move cursor outside of the graph.

Tested on Chrome, in Firefox the horizontal scrolling does not work in general - which is fine for my purposes.

Feedback welcome!
