### PR TITLE
Min/MaxDate as option

### DIFF
--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -175,7 +175,7 @@
             source: [],
             holidays: [],
             minDate : null,
-			maxDate : null,
+            maxDate : null,
             // paging
             itemsPerPage: 7,
             // localisation
@@ -1464,12 +1464,12 @@
                 case "days":
                     /* falls through */
                 default:
-                	if (settings.maxDate == null) {
-                    	maxDate.setHours(0);
-                    	maxDate.setDate(maxDate.getDate() + 3);
-                	} else {
-						maxDate = tools.dateDeserialize(settings.maxDate);
-                	}
+                    if (settings.maxDate == null) {
+                        maxDate.setHours(0);
+                        maxDate.setDate(maxDate.getDate() + 3);
+                    } else {
+                        maxDate = tools.dateDeserialize(settings.maxDate);
+                    }
                 }
                 return maxDate;
             },
@@ -1504,12 +1504,12 @@
                 case "days":
                     /* falls through */
                 default:
-					if (settings.minDate == null) {
-                    	minDate.setHours(0, 0, 0, 0);
-                    	minDate.setDate(minDate.getDate() - 3);
-					} else {
-						minDate = tools.dateDeserialize(settings.minDate);
-					}
+                    if (settings.minDate == null) {
+                        minDate.setHours(0, 0, 0, 0);
+                        minDate.setDate(minDate.getDate() - 3);
+                    } else {
+                        minDate = tools.dateDeserialize(settings.minDate);
+                    }
                 }
                 return minDate;
             },

--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -174,6 +174,8 @@
         var settings = {
             source: [],
             holidays: [],
+            minDate : null,
+			maxDate : null,
             // paging
             itemsPerPage: 7,
             // localisation
@@ -1462,8 +1464,12 @@
                 case "days":
                     /* falls through */
                 default:
-                    maxDate.setHours(0);
-                    maxDate.setDate(maxDate.getDate() + 3);
+                	if (settings.maxDate == null) {
+                    	maxDate.setHours(0);
+                    	maxDate.setDate(maxDate.getDate() + 3);
+                	} else {
+						maxDate = tools.dateDeserialize(settings.maxDate);
+                	}
                 }
                 return maxDate;
             },
@@ -1498,8 +1504,12 @@
                 case "days":
                     /* falls through */
                 default:
-                    minDate.setHours(0, 0, 0, 0);
-                    minDate.setDate(minDate.getDate() - 3);
+					if (settings.minDate == null) {
+                    	minDate.setHours(0, 0, 0, 0);
+                    	minDate.setDate(minDate.getDate() - 3);
+					} else {
+						minDate = tools.dateDeserialize(settings.minDate);
+					}
                 }
                 return minDate;
             },


### PR DESCRIPTION
Adding minDate/maxDate as options for defining exact lower and upper date bounds instead of using the calculations made in the gantt char.

Addresses Issue #143.