### PR TITLE
Issue 180: headerPanel with fixed position

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -102,6 +102,12 @@
     overflow: hidden;
 }
 
+.fn-gantt .headerPanel {
+    position: fixed;
+    overflow: visible;
+    z-index: 15;
+}
+
 .fn-gantt .dataPanel {
     margin-left: 0px;
     border-right: 1px solid #DDD;

--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -563,7 +563,7 @@
                         '<div class="fn-label">' + settings.dow[day.getDay()] + '</div></div>');
 
                     headerPanel = $('<div class="headerPanel" style="width: '
-							+ range.length * tools.getCellSize() + 'px;"/>');
+                            + range.length * tools.getCellSize() + 'px;"/>');
 
                     // Append panel elements
                     headerPanel.append(
@@ -646,7 +646,7 @@
                         '</div></div>');
 
                     headerPanel = $('<div class="headerPanel" style="width: '
-							+ range.length * tools.getCellSize() + 'px;"/>');
+                            + range.length * tools.getCellSize() + 'px;"/>');
 
                     // Append panel elements
                     headerPanel.append(
@@ -700,7 +700,7 @@
                         '</div></div>');
 
                     headerPanel = $('<div class="headerPanel" style="width: '
-							+ range.length * tools.getCellSize() + 'px;"/>');
+                            + range.length * tools.getCellSize() + 'px;"/>');
 
                     // Append panel elements
                     headerPanel.append(
@@ -783,7 +783,7 @@
                         '</div></div>');
 
                     headerPanel = $('<div class="headerPanel" style="width: '
-							+ range.length * tools.getCellSize() + 'px;"/>');
+                            + range.length * tools.getCellSize() + 'px;"/>');
 
                     // Append panel elements
                     headerPanel.append(
@@ -793,9 +793,9 @@
                         $row.clone().html(dowArr.join(""))
                     );
                 }
-                
+
                 var dataPanel = core.dataPanel(element, range.length * tools.getCellSize());
-				dataPanel.append(headerPanel);
+                dataPanel.append(headerPanel);
 
                 return $('<div class="rightPanel"></div>').append(dataPanel);
             },

--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -449,7 +449,7 @@
                 var i, len;
                 var year, month, week, day;
                 var rday, dayClass;
-                var dataPanel;
+                var headerWidth, headerPanel;
 
                 // Setup the headings based on the chosen `settings.scale`
                 switch (settings.scale) {
@@ -562,10 +562,11 @@
                         'style="width: ' + tools.getCellSize() * hoursInDay + 'px;">' +
                         '<div class="fn-label">' + settings.dow[day.getDay()] + '</div></div>');
 
-                    dataPanel = core.dataPanel(element, range.length * tools.getCellSize());
+                    headerPanel = $('<div class="headerPanel" style="width: '
+							+ range.length * tools.getCellSize() + 'px;"/>');
 
                     // Append panel elements
-                    dataPanel.append(
+                    headerPanel.append(
                         $row.clone().html(yearArr.join("")),
                         $row.clone().html(monthArr.join("")),
                         $row.clone().html(dayArr.join("")),
@@ -644,10 +645,11 @@
                         settings.months[month] +
                         '</div></div>');
 
-                    dataPanel = core.dataPanel(element, range.length * tools.getCellSize());
+                    headerPanel = $('<div class="headerPanel" style="width: '
+							+ range.length * tools.getCellSize() + 'px;"/>');
 
                     // Append panel elements
-                    dataPanel.append(
+                    headerPanel.append(
                         $row.clone().html(yearArr.join("")),
                         $row.clone().html(monthArr.join("")),
                         $row.clone().html(dayArr.join(""))
@@ -697,10 +699,11 @@
                         settings.months[month] +
                         '</div></div>');
 
-                    dataPanel = core.dataPanel(element, range.length * tools.getCellSize());
+                    headerPanel = $('<div class="headerPanel" style="width: '
+							+ range.length * tools.getCellSize() + 'px;"/>');
 
                     // Append panel elements
-                    dataPanel.append(
+                    headerPanel.append(
                         $row.clone().html(yearArr.join("")),
                         $row.clone().html(monthArr.join("")),
                         $row.clone().html(dayArr.join("")),
@@ -779,16 +782,20 @@
                         settings.months[month] +
                         '</div></div>');
 
-                    dataPanel = core.dataPanel(element, range.length * tools.getCellSize());
+                    headerPanel = $('<div class="headerPanel" style="width: '
+							+ range.length * tools.getCellSize() + 'px;"/>');
 
                     // Append panel elements
-                    dataPanel.append(
+                    headerPanel.append(
                         $row.clone().html(yearArr.join("")),
                         $row.clone().html(monthArr.join("")),
                         $row.clone().html(dayArr.join("")),
                         $row.clone().html(dowArr.join(""))
                     );
                 }
+                
+                var dataPanel = core.dataPanel(element, range.length * tools.getCellSize());
+				dataPanel.append(headerPanel);
 
                 return $('<div class="rightPanel"></div>').append(dataPanel);
             },


### PR DESCRIPTION
Adding a new headerPanel which will contain the date headers and can be used with CSS fixed position styling to have a header which remains visible when scrolling down as requested in Issue #180.